### PR TITLE
Investigate login failure after token retrieval

### DIFF
--- a/src/components/layout/DashboardHeader.tsx
+++ b/src/components/layout/DashboardHeader.tsx
@@ -12,6 +12,7 @@ import {
 import { Bell, MessageSquare, Settings, LogOut, MapPin, Search, Menu } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/contexts/AuthContext';
+import { roleColors } from '@/data/mockUsers';
 
 interface DashboardHeaderProps {
   onLogout: () => void;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,7 +25,9 @@ const badgeVariants = cva(
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+    VariantProps<typeof badgeVariants> {
+  children?: React.ReactNode
+}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (


### PR DESCRIPTION
Import `roleColors` in `DashboardHeader` and add `children` prop to `BadgeProps`.

This resolves a `ReferenceError` for `roleColors` in `DashboardHeader.tsx` and fixes a type-checking issue in `src/components/ui/badge.tsx` to allow content within the Badge component.

---
<a href="https://cursor.com/background-agent?bcId=bc-0040c8a7-6aad-4ebb-959b-67e6e6b75049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0040c8a7-6aad-4ebb-959b-67e6e6b75049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

